### PR TITLE
Vic 168 user is taken to the live url upon login no matter what should simply be taken to the docs page of whatever instance of the site is running via react router bootstrap package

### DIFF
--- a/frontend/frontend_2/src/components/sidebars/DocumentList.js
+++ b/frontend/frontend_2/src/components/sidebars/DocumentList.js
@@ -15,7 +15,9 @@ function DocumentList(props){
 
   const addDocument = e => {
 
-    return fetch('${API_URL}/api/docs/add/', {
+
+    let docListAddDocAPIstring = API_URL + "/api/docs/add/"
+    return fetch(docListAddDocAPIstring, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -28,7 +30,8 @@ function DocumentList(props){
 
   let documents = []
   const getDocuments = e => {
-    return fetch('${API_URL}/api/docs/list/', {
+    let docListGetDocsAPIstring = API_URL + "/api/docs/list/"
+    return fetch(docListGetDocsAPIstring, {
         method: 'GET',
         headers: {
             'Content-Type': 'application/json',

--- a/frontend/frontend_2/src/components/views/DocumentView/DocumentView.js
+++ b/frontend/frontend_2/src/components/views/DocumentView/DocumentView.js
@@ -20,7 +20,8 @@ export default function DocumentView() {
 
     const handleSubmit = e => {
         e.preventDefault();
-        window.location.replace('${REACT_URL}/logout');
+        let docViewHandleSubmitString = REACT_URL + "/logout"
+        window.location.replace(docViewHandleSubmitString);
     }
 
     return(

--- a/frontend/frontend_2/src/components/views/auth/Login.js
+++ b/frontend/frontend_2/src/components/views/auth/Login.js
@@ -11,7 +11,8 @@ import { API_URL, REACT_URL } from './../../../config'
 
 async function loginUser(credentials) {
     //login logic/talking to server goes here
-    return fetch('${API_URL}/api/users/auth/login/', {
+    let loginString = API_URL + '/api/users/auth/login/'
+    return fetch(loginString, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'

--- a/frontend/frontend_2/src/components/views/auth/Login.js
+++ b/frontend/frontend_2/src/components/views/auth/Login.js
@@ -30,7 +30,8 @@ export default function Login( {setToken} ) {
 
     useEffect(() => {
         if(sessionStorage.getItem('token') !== null) {
-            window.location.replace('${REACT_URL}/docs/');
+            let windowString = REACT_URL+ '/docs/'
+            window.location.replace(windowString);
         } else {
             setLoading(false);
         }
@@ -42,7 +43,8 @@ export default function Login( {setToken} ) {
         setToken(token.key);
         console.log("token in login.js: " + token.key)
         if(token.key){
-            window.location.replace('${REACT_URL}/docs/');
+            let onSubmitString = REACT_URL+ '/docs/'
+            window.location.replace(onSubmitString);
         } else {
             setEmail('');
             setPassword('');

--- a/frontend/frontend_2/src/components/views/auth/Logout.js
+++ b/frontend/frontend_2/src/components/views/auth/Logout.js
@@ -6,7 +6,8 @@ const Logout = () => {
 
   useEffect(() => {
     if (sessionStorage.getItem('token') == null) {
-      window.location.replace('${REACT_URL}/login');
+      let logoutUseEffectString = REACT_URL + "/login"
+      window.location.replace(logoutUseEffectString);
     } else {
       setLoading(false);
     }
@@ -15,7 +16,8 @@ const Logout = () => {
   const handleLogout = e => {
     e.preventDefault();
 
-    fetch('${API_URL}/api/users/auth/logout/', {
+    let logoutHandleLogoutString = API_URL + "/api/users/auth/logout/"
+    fetch(logoutHandleLogoutString, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -26,7 +28,8 @@ const Logout = () => {
       .then(data => {
         console.log(data);
         sessionStorage.clear();
-        window.location.replace('${REACT_URL}/login');
+        let logoutHandleLogoutString = REACT_URL + "/login"
+        window.location.replace(logoutHandleLogoutString);
       });
   };
 

--- a/frontend/frontend_2/src/components/views/auth/Register.js
+++ b/frontend/frontend_2/src/components/views/auth/Register.js
@@ -8,8 +8,8 @@ import { API_URL, REACT_URL } from './../../../config'
 
 async function registerUser(credentials) {
     //login logic/talking to server goes here
-
-    return fetch('${API_URL}/api/users/auth/register/', {
+    let registerUserAPIstring = API_URL + '/api/users/auth/register/'
+    return fetch(registerUserAPIstring, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -28,7 +28,8 @@ export default function Register( {setToken} ) {
 
   useEffect(() => {
     if (sessionStorage.getItem('token') !== null) {
-      window.location.replace('${REACT_URL}/docs/');
+        let reigsterUseEffectString = REACT_URL + "/docs"
+        window.location.replace(reigsterUseEffectString);
     } else {
       setLoading(false);
     }
@@ -49,7 +50,8 @@ export default function Register( {setToken} ) {
     setToken(token.key);
 
     if(token.key){
-            window.location.replace('${REACT_URL}/docs/');
+            let registerOnSubmitString = REACT_URL+ '/docs/'
+            window.location.replace(registerOnSubmitString);
         } else {
             setEmail('');
             setPassword1('');

--- a/frontend/frontend_2/src/config.js
+++ b/frontend/frontend_2/src/config.js
@@ -1,7 +1,8 @@
 
-const dev = true;
+const dev = false;
 const test = false;
 const prod =false;
+const testFrontProdBack = true;
 
 let api_url;
 let react_url;
@@ -14,6 +15,11 @@ if(dev){
 if(prod){
     api_url = 'https://vicsr-api-test.herokuapp.com';
     react_url = 'http://vicsr.herokuapp.com';
+}
+
+if(testFrontProdBack){
+    api_url = 'https://vicsr-api-test.herokuapp.com';
+    react_url = 'http://localhost:3000';
 }
 
 export const API_URL = api_url, REACT_URL = react_url;


### PR DESCRIPTION
I built upon Alyssa's work to fix the bug of user's being directed to the wrong URL when they are testing vs when they are accessing the site from production. I added a new config setup where the live API can be used while using a production version of the front-end, and then I fixed the way strings are passed to the window.replace() function calls as well as API fetch() calls. The way they were passed before did not work, but this should. One should test this version by noting that testFrontProdBack is set as true in config.js, and then go through the login/register/logout workflows. This also ensures that bootstrap is available in all views when accessing them through the normal user workflow (logging through the UI)