### PR TITLE
Changed package.json from referencing 'react-script start' in nodemod…

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "node_modules/.bin/react-scripts start",
+    "start": "react-scripts start",
     "build": "node_modules/.bin/react-scripts build",
     "test": "node_modules/.bin/jest",
     "eject": "node_modules/.bin/react-scripts eject"


### PR DESCRIPTION
Fixed bug after project restructuring where 'npm start' would not recognize the path to 'react-scripts' commands. Package.json is changed to reference 'react-script start' properly 