### PR TITLE
Vic 210 UI clear highlight upon document change redraw highlight

### DIFF
--- a/src/components/DocumentPage.js
+++ b/src/components/DocumentPage.js
@@ -52,7 +52,7 @@ export default function DocumentPage(props){
 
 
         if(props.highlighting != null && props.highlighting !== ""){
-            canvas.current.loadSaveData(props.highlighting)
+            canvas.current.loadSaveData(props.highlighting, true)
         }
         else{
             console.log("erasing all highlight")
@@ -63,7 +63,7 @@ export default function DocumentPage(props){
     return(
         <div>
             {/* The 80 at the end of the hex code sets the transparency*/}
-            <CanvasDraw ref={canvas} onChange={(event) => saveHighlightToServer(props.currentPageID)} enablePanAndZoom = {false} clampLinesToDocument={true}  saveData={currentHighlight} imgSrc={props.URL} canvasHeight={1123} canvasWidth={794} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
+            <CanvasDraw ref={canvas} onChange={(event) => saveHighlightToServer(props.currentPageID)} enablePanAndZoom = {false} clampLinesToDocument={true}  saveData={null} imgSrc={props.URL} canvasHeight={1123} canvasWidth={794} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
         </div>
     )
 }

--- a/src/components/DocumentPage.js
+++ b/src/components/DocumentPage.js
@@ -6,6 +6,8 @@ import {API_URL} from "../config";
 export default function DocumentPage(props){
     const canvas = useRef(null)
 
+    //this function is passed as a property to the CanvasDraw component, which will be called every time the canvas is updated in some way
+    //this means new background image, new highlight, etc will fire this func
     async function saveHighlightToServer(lowLevelDocumentId){
         if(props.URL === ""){
             console.log("no page, not attempting save")
@@ -14,8 +16,8 @@ export default function DocumentPage(props){
             console.log("attempting save")
             //get highlight from current view and send to backend to save
             let highlightData = canvas.current.getSaveData()
-            console.log(highlightData)
-            console.log(typeof highlightData)
+            //console.log(highlightData)
+            //console.log(typeof highlightData)
             let studySet;
 
             let myHeaders = new Headers();
@@ -44,16 +46,18 @@ export default function DocumentPage(props){
 
     }
 
-    let [currentHighlight, setCurrentHighlight] = useState(null)
     //this will happen every page click and doc choose.
     useEffect(() => {
         //console.log("DocumentPage displaying: " + props.URL);
         //console.log("Highlighting: " + props.highlighting)
 
-
+        //props.highlighting is declared as null originally, and a document which has never tried to save highlight data will always
+        //be listed as "" in the database. If neither of these cases are true, then we can load valid highlight data
+        //per the CanvasDraw component and should try to do so
         if(props.highlighting != null && props.highlighting !== ""){
             canvas.current.loadSaveData(props.highlighting, true)
         }
+        //no highlight
         else{
             console.log("erasing all highlight")
             canvas.current.eraseAll()

--- a/src/components/DocumentPage.js
+++ b/src/components/DocumentPage.js
@@ -20,7 +20,7 @@ export default function DocumentPage(props){
     return(
         <div>
             {/* The 80 at the end of the hex code sets the transparency*/}
-            <CanvasDraw ref={canvas} enablePanAndZoom = {false} clampLinesToDocument={true} saveData={props.highlighting} imgSrc={props.URL} canvasHeight={633} canvasWidth={489} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
+            <CanvasDraw ref={canvas} enablePanAndZoom = {false} clampLinesToDocument={true} saveData={props.highlighting} imgSrc={props.URL} canvasHeight={1123} canvasWidth={794} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
         </div>
     )
 }

--- a/src/components/DocumentPage.js
+++ b/src/components/DocumentPage.js
@@ -7,34 +7,41 @@ export default function DocumentPage(props){
     const canvas = useRef(null)
 
     async function saveHighlightToServer(lowLevelDocumentId){
-        //get highlight from current view and send to backend to save
-        let highlightData = canvas.current.getSaveData()
-        console.log(highlightData)
-        console.log(typeof highlightData)
-        let studySet;
+        if(props.URL === ""){
+            console.log("no page, not attempting save")
+        }
+        else{
+            console.log("attempting save")
+            //get highlight from current view and send to backend to save
+            let highlightData = canvas.current.getSaveData()
+            console.log(highlightData)
+            console.log(typeof highlightData)
+            let studySet;
 
-        let myHeaders = new Headers();
-        myHeaders.append("Authorization", "Token " + sessionStorage.getItem('token'))
+            let myHeaders = new Headers();
+            myHeaders.append("Authorization", "Token " + sessionStorage.getItem('token'))
 
-        let formdata = new FormData();
-        formdata.append("highlight", highlightData)
+            let formdata = new FormData();
+            formdata.append("highlight", highlightData)
 
-        let requestOptions = {
-            method: 'POST',
-            headers: myHeaders,
-            body: formdata,
-            redirect: 'follow'
+            let requestOptions = {
+                method: 'POST',
+                headers: myHeaders,
+                body: formdata,
+                redirect: 'follow'
+            }
+
+            try{
+                let saveHighlight = API_URL + "/api/files/update/" + lowLevelDocumentId
+                //COMMENTED OUT SO IT DOESNT DDOS THE BACKEND
+                //const response = await fetch(saveHighlight, requestOptions);
+                //studySet = response
+                //console.log(studySet)
+            }catch (error){
+                console.error(error)
+            }
         }
 
-        try{
-            let saveHighlight = API_URL + "/api/files/update/" + lowLevelDocumentId
-            const response = await fetch(saveHighlight, requestOptions);
-            studySet = response
-            console.log(studySet)
-        }catch (error){
-            console.error(error)
-        }
-        return studySet;
     }
 
     let [currentHighlight, setCurrentHighlight] = useState(null)
@@ -42,10 +49,6 @@ export default function DocumentPage(props){
     useEffect(() => {
         //console.log("DocumentPage displaying: " + props.URL);
         //console.log("Highlighting: " + props.highlighting)
-
-        if(props.URL){
-            console.log("attempting save")
-        }
 
 
         if(props.highlighting != null && props.highlighting !== ""){

--- a/src/components/DocumentPage.js
+++ b/src/components/DocumentPage.js
@@ -1,38 +1,66 @@
 import CanvasDraw from "react-canvas-draw";
 import ExampleImage from '../assets/Screen Shot 2022-03-24 at 1.05.06 PM.png'
-import {useEffect, useRef} from "react";
+import {useEffect, useRef, useState} from "react";
+import {API_URL} from "../config";
 
 export default function DocumentPage(props){
     const canvas = useRef(null)
 
+    async function saveHighlightToServer(lowLevelDocumentId){
+        //get highlight from current view and send to backend to save
+        let highlightData = canvas.current.getSaveData()
+        console.log(highlightData)
+        console.log(typeof highlightData)
+        let studySet;
+
+        let myHeaders = new Headers();
+        myHeaders.append("Authorization", "Token " + sessionStorage.getItem('token'))
+
+        let formdata = new FormData();
+        formdata.append("highlight", highlightData)
+
+        let requestOptions = {
+            method: 'POST',
+            headers: myHeaders,
+            body: formdata,
+            redirect: 'follow'
+        }
+
+        try{
+            let saveHighlight = API_URL + "/api/files/update/" + lowLevelDocumentId
+            const response = await fetch(saveHighlight, requestOptions);
+            studySet = response
+            console.log(studySet)
+        }catch (error){
+            console.error(error)
+        }
+        return studySet;
+    }
+
+    let [currentHighlight, setCurrentHighlight] = useState(null)
     //this will happen every page click and doc choose.
     useEffect(() => {
         //console.log("DocumentPage displaying: " + props.URL);
         //console.log("Highlighting: " + props.highlighting)
 
-        //get highlight from current view and send to backend to save
-        let saveData = canvas.current.getSaveData()
-        console.log(saveData)
-        var parse = JSON.parse(saveData)
-        if(parse.lines.length === 0){
-            console.log("save data is empty")
-        }
-        else{
-            console.log("save data has something")
+        if(props.URL){
+            console.log("attempting save")
         }
 
-        if(props.highlighting != null){
+
+        if(props.highlighting != null && props.highlighting !== ""){
             canvas.current.loadSaveData(props.highlighting)
         }
         else{
+            console.log("erasing all highlight")
             canvas.current.eraseAll()
         }
-        }, [props.URL, props.highlighting]);
+        }, [props.URL]);
 
     return(
         <div>
             {/* The 80 at the end of the hex code sets the transparency*/}
-            <CanvasDraw ref={canvas} enablePanAndZoom = {false} clampLinesToDocument={true} saveData={props.highlighting} imgSrc={props.URL} canvasHeight={1123} canvasWidth={794} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
+            <CanvasDraw ref={canvas} onChange={(event) => saveHighlightToServer(props.currentPageID)} enablePanAndZoom = {false} clampLinesToDocument={true}  saveData={currentHighlight} imgSrc={props.URL} canvasHeight={1123} canvasWidth={794} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
         </div>
     )
 }

--- a/src/components/DocumentPage.js
+++ b/src/components/DocumentPage.js
@@ -8,7 +8,19 @@ export default function DocumentPage(props){
     //this will happen every page click and doc choose.
     useEffect(() => {
         //console.log("DocumentPage displaying: " + props.URL);
-        console.log("Highlighting: " + props.highlighting)
+        //console.log("Highlighting: " + props.highlighting)
+
+        //get highlight from current view and send to backend to save
+        let saveData = canvas.current.getSaveData()
+        console.log(saveData)
+        var parse = JSON.parse(saveData)
+        if(parse.lines.length === 0){
+            console.log("save data is empty")
+        }
+        else{
+            console.log("save data has something")
+        }
+
         if(props.highlighting != null){
             canvas.current.loadSaveData(props.highlighting)
         }

--- a/src/components/DocumentPage.js
+++ b/src/components/DocumentPage.js
@@ -11,7 +11,7 @@ export default function DocumentPage(props){
     return(
         <div>
             {/* The 80 at the end of the hex code sets the transparency*/}
-            <CanvasDraw enablePanAndZoom = {false} clampLinesToDocument={true} imgSrc={props.URL} canvasHeight={685} canvasWidth={500} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
+            <CanvasDraw enablePanAndZoom = {false} clampLinesToDocument={true} imgSrc={props.URL} canvasHeight={633} canvasWidth={489} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
         </div>
     )
 }

--- a/src/components/DocumentPage.js
+++ b/src/components/DocumentPage.js
@@ -1,17 +1,26 @@
 import CanvasDraw from "react-canvas-draw";
 import ExampleImage from '../assets/Screen Shot 2022-03-24 at 1.05.06 PM.png'
-import {useEffect} from "react";
+import {useEffect, useRef} from "react";
 
 export default function DocumentPage(props){
+    const canvas = useRef(null)
 
+    //this will happen every page click and doc choose.
     useEffect(() => {
         //console.log("DocumentPage displaying: " + props.URL);
-        }, [props.URL]);
+        console.log("Highlighting: " + props.highlighting)
+        if(props.highlighting != null){
+            canvas.current.loadSaveData(props.highlighting)
+        }
+        else{
+            canvas.current.eraseAll()
+        }
+        }, [props.URL, props.highlighting]);
 
     return(
         <div>
             {/* The 80 at the end of the hex code sets the transparency*/}
-            <CanvasDraw enablePanAndZoom = {false} clampLinesToDocument={true} imgSrc={props.URL} canvasHeight={633} canvasWidth={489} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
+            <CanvasDraw ref={canvas} enablePanAndZoom = {false} clampLinesToDocument={true} saveData={props.highlighting} imgSrc={props.URL} canvasHeight={633} canvasWidth={489} brushColor={"#FFFF0080"} catenaryColor={"#FFFF0080"}/>
         </div>
     )
 }

--- a/src/components/sidebars/DocumentList/DocumentListLoader.js
+++ b/src/components/sidebars/DocumentList/DocumentListLoader.js
@@ -33,7 +33,7 @@ function DocumentListLoader(props){
         //console.log("Done fetching documents")
 
         }, []);
-
+    console.log(data.docsFromServer)
 
     return(
         <DocumentList documents = {data.docsFromServer} numberOfDocs = {data.numDocs} isLoading ={data.isFetching} chooseDocument = {docPicker}/>

--- a/src/components/sidebars/DocumentList/DocumentListLoader.js
+++ b/src/components/sidebars/DocumentList/DocumentListLoader.js
@@ -12,7 +12,7 @@ function DocumentListLoader(props){
     useEffect( () =>{
         async function fetchDocuments() {
             try {
-                setData({docsFromServer: data.docsFromServer, numDocs:data.numDocs, isFetching: false})
+                setData({docsFromServer: data.docsFromServer, numDocs: data.numDocs, isFetching: false})
                 let docListGetDocsAPIstring = API_URL + "/api/docs/list/"
                 const response = await fetch(docListGetDocsAPIstring, {
                     method: 'GET',
@@ -22,19 +22,18 @@ function DocumentListLoader(props){
                     },
                 });
                 const docs = await response.json();
-                setData({docsFromServer: docs, numDocs:docs.length, isFetching: false})
+                setData({docsFromServer: docs, numDocs: docs.length, isFetching: false})
             } catch (error) {
                 console.error(error);
-                setData({docsFromServer: data.docsFromServer, numDocs:data.numDocs, isFetching: false})
+                setData({docsFromServer: data.docsFromServer, numDocs: data.numDocs, isFetching: false})
             }
         }
-        //console.log(data.docsFromServer)
-        fetchDocuments()
-        //console.log("Done fetching documents")
-        props.setNeedHighlight(false);
-
-        }, [props.needHighlight]);
-    console.log(data.docsFromServer)
+        if(props.needHighlight){
+            console.log("Documents being fetched")
+            fetchDocuments()
+            props.setNeedHighlight(false);
+        }
+    }, [props.needHighlight]);
 
     return(
         <DocumentList documents = {data.docsFromServer} numberOfDocs = {data.numDocs} isLoading ={data.isFetching} chooseDocument = {docPicker}/>

--- a/src/components/sidebars/DocumentList/DocumentListLoader.js
+++ b/src/components/sidebars/DocumentList/DocumentListLoader.js
@@ -31,8 +31,9 @@ function DocumentListLoader(props){
         //console.log(data.docsFromServer)
         fetchDocuments()
         //console.log("Done fetching documents")
+        props.setNeedHighlight(false);
 
-        }, []);
+        }, [props.needHighlight]);
     console.log(data.docsFromServer)
 
     return(

--- a/src/components/sidebars/DocumentList/DocumentListLoader.js
+++ b/src/components/sidebars/DocumentList/DocumentListLoader.js
@@ -9,7 +9,9 @@ function DocumentListLoader(props){
         props.chooseDoc(topLevelID, urls);
     }
 
+    //will happen upon component loading in and then if props.highlight changes
     useEffect( () =>{
+        //function defined
         async function fetchDocuments() {
             try {
                 setData({docsFromServer: data.docsFromServer, numDocs: data.numDocs, isFetching: false})
@@ -28,6 +30,10 @@ function DocumentListLoader(props){
                 setData({docsFromServer: data.docsFromServer, numDocs: data.numDocs, isFetching: false})
             }
         }
+
+        //fetchDocuments will be called only if props.needHighlight is true
+        //the variable which provides the Boolean for props.needHighlight is defined as true originally in the DocumentView
+        //It will be turned back to true whenever a document is clicked or the page is turned
         if(props.needHighlight){
             console.log("Documents being fetched")
             fetchDocuments()

--- a/src/components/views/DocumentView/DocumentView.js
+++ b/src/components/views/DocumentView/DocumentView.js
@@ -12,17 +12,22 @@ export default function DocumentView() {
     let[data, setData] = useState({currentDocID: "", pages: null})
     let[shownPage, setShowPage] = useState("")
     let[currentPage, setCurrentPage] = useState(0)
+    let[pageHighlightData, setPageHighlightData] = useState(null)
 
     useEffect(() => {
-        if(data.pages){setShowPage(data.pages[currentPage].file)}
-        //console.log("document: " + shownPage + " chosen");
-        //console.log("current page number is: " + currentPage)
+        if(data.pages){
+            setShowPage(data.pages[currentPage].file)}
+
+            //console.log("document: " + shownPage + " chosen");
+            //console.log("current page number is: " + currentPage)
         }, [data.currentDocID, shownPage, currentPage]);
 
     function chooseDocument(topLevelID, urls) {
         setData({currentDocID: topLevelID, pages: urls});
         setCurrentPage(0)
         setShowPage(urls[currentPage].file)
+        let subPageID = urls[currentPage].id
+        fetchPageHighlight(subPageID)
     }
 
     function previousPage() {

--- a/src/components/views/DocumentView/DocumentView.js
+++ b/src/components/views/DocumentView/DocumentView.js
@@ -22,12 +22,19 @@ export default function DocumentView() {
             //console.log("current page number is: " + currentPage)
         }, [data.currentDocID, shownPage, currentPage]);
 
+    function fetchPageHighlight(subPageID) {
+        //LOGIC FOR TALKING TO SERVER HERE, GETTING HIGHLIGHT DATA, AND FORMATTING
+        //RETURN SO WE CAN SET WITH USESTATE
+        return null
+
+    }
+
     function chooseDocument(topLevelID, urls) {
         setData({currentDocID: topLevelID, pages: urls});
         setCurrentPage(0)
         setShowPage(urls[currentPage].file)
         let subPageID = urls[currentPage].id
-        fetchPageHighlight(subPageID)
+        setPageHighlightData(fetchPageHighlight(subPageID))
     }
 
     function previousPage() {
@@ -60,7 +67,7 @@ export default function DocumentView() {
 
             </div>
             <div className="canvas">
-                <DocumentPage URL = {shownPage}/>
+                <DocumentPage URL = {shownPage} highlighting = {pageHighlightData} />
                 <div>
                     <Button onClick = { () => previousPage()}>Previous page</Button>
                     <Button onClick = { () => nextPage()}>Next page</Button>

--- a/src/components/views/DocumentView/DocumentView.js
+++ b/src/components/views/DocumentView/DocumentView.js
@@ -9,6 +9,7 @@ import CustomNavbar from "./CustomNavbar";
 
 export default function DocumentView() {
 
+    //state variables
     let[data, setData] = useState({currentDocID: "", pages: null})
     let[shownPage, setShowPage] = useState("")
     let[currentPageNumber, setCurrentPageNumber] = useState(0)
@@ -21,7 +22,6 @@ export default function DocumentView() {
             let currentPageRef = data.pages[currentPageNumber]
             setShowPage(currentPageRef.file)
             setCurrentPageID(currentPageRef.id)
-            setNeedHighlight(true)
             setPageHighlightData(currentPageRef.highlight)
         }
         //console.log("document: " + shownPage + " chosen");
@@ -32,13 +32,16 @@ export default function DocumentView() {
     function chooseDocument(topLevelID, urls) {
         setData({currentDocID: topLevelID, pages: urls});
         setCurrentPageNumber(0)
-        setCurrentPageID(urls[currentPageNumber].id)
-        setShowPage(urls[currentPageNumber].file)
+        let currentPageRef = urls[currentPageNumber]
+        setCurrentPageID(currentPageRef.id)
+        setShowPage(currentPageRef.file)
+        setPageHighlightData(currentPageRef.highlight)
         setNeedHighlight(true)
     }
 
     function previousPage() {
         if(currentPageNumber > 0){
+            setNeedHighlight(true)
             setCurrentPageNumber(currentPageNumber - 1)
         }
         else{
@@ -48,6 +51,7 @@ export default function DocumentView() {
 
     function nextPage() {
         if(currentPageNumber !== data.pages.length -1){
+            setNeedHighlight(true)
             setCurrentPageNumber(currentPageNumber + 1)
         }
         else{

--- a/src/components/views/DocumentView/DocumentView.js
+++ b/src/components/views/DocumentView/DocumentView.js
@@ -11,16 +11,18 @@ export default function DocumentView() {
 
     let[data, setData] = useState({currentDocID: "", pages: null})
     let[shownPage, setShowPage] = useState("")
-    let[currentPage, setCurrentPage] = useState(0)
+    let[currentPageNumber, setCurrentPageNumber] = useState(0)
     let[pageHighlightData, setPageHighlightData] = useState(null)
 
     useEffect(() => {
         if(data.pages){
-            setShowPage(data.pages[currentPage].file)}
-
-            //console.log("document: " + shownPage + " chosen");
-            //console.log("current page number is: " + currentPage)
-        }, [data.currentDocID, shownPage, currentPage]);
+            let currentPageRef = data.pages[currentPageNumber]
+            setShowPage(currentPageRef.file)
+            setPageHighlightData(fetchPageHighlight(currentPageRef.id))
+        }
+        //console.log("document: " + shownPage + " chosen");
+        //console.log("current page number is: " + currentPageNumber)
+        }, [data.currentDocID, shownPage, currentPageNumber]);
 
     function fetchPageHighlight(subPageID) {
         //LOGIC FOR TALKING TO SERVER HERE, GETTING HIGHLIGHT DATA, AND FORMATTING
@@ -31,15 +33,15 @@ export default function DocumentView() {
 
     function chooseDocument(topLevelID, urls) {
         setData({currentDocID: topLevelID, pages: urls});
-        setCurrentPage(0)
-        setShowPage(urls[currentPage].file)
-        let subPageID = urls[currentPage].id
+        setCurrentPageNumber(0)
+        setShowPage(urls[currentPageNumber].file)
+        let subPageID = urls[currentPageNumber].id
         setPageHighlightData(fetchPageHighlight(subPageID))
     }
 
     function previousPage() {
-        if(currentPage > 0){
-            setCurrentPage(currentPage - 1)
+        if(currentPageNumber > 0){
+            setCurrentPageNumber(currentPageNumber - 1)
         }
         else{
             console.log("error, page previous clicked while on first page")
@@ -47,8 +49,8 @@ export default function DocumentView() {
     }
 
     function nextPage() {
-        if(currentPage != data.pages.length -1){
-            setCurrentPage(currentPage + 1)
+        if(currentPageNumber != data.pages.length -1){
+            setCurrentPageNumber(currentPageNumber + 1)
         }
         else{
             console.log("error, page next clicked while on last page")

--- a/src/components/views/DocumentView/DocumentView.js
+++ b/src/components/views/DocumentView/DocumentView.js
@@ -27,6 +27,10 @@ export default function DocumentView() {
     function fetchPageHighlight(subPageID) {
         //LOGIC FOR TALKING TO SERVER HERE, GETTING HIGHLIGHT DATA, AND FORMATTING
         //RETURN SO WE CAN SET WITH USESTATE
+
+        //return string of save data if availible
+
+        //return null if no entry
         return null
 
     }

--- a/src/components/views/DocumentView/DocumentView.js
+++ b/src/components/views/DocumentView/DocumentView.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react'
 import {Link} from "react-router-dom";
-import {REACT_URL } from '../../../config'
+import {API_URL, REACT_URL} from '../../../config'
 import DocumentListLoader from "../../sidebars/DocumentList/DocumentListLoader.js";
 import DocumentPage from "../../DocumentPage";
 import {Button} from "react-bootstrap"
@@ -12,35 +12,29 @@ export default function DocumentView() {
     let[data, setData] = useState({currentDocID: "", pages: null})
     let[shownPage, setShowPage] = useState("")
     let[currentPageNumber, setCurrentPageNumber] = useState(0)
+    let[currentPageID, setCurrentPageID] = useState(null)
     let[pageHighlightData, setPageHighlightData] = useState(null)
+    let[needHighlight, setNeedHighlight] = useState(true)
 
     useEffect(() => {
         if(data.pages){
             let currentPageRef = data.pages[currentPageNumber]
             setShowPage(currentPageRef.file)
-            setPageHighlightData(fetchPageHighlight(currentPageRef.id))
+            setCurrentPageID(currentPageRef.id)
+            setNeedHighlight(true)
+            setPageHighlightData(currentPageRef.highlight)
         }
         //console.log("document: " + shownPage + " chosen");
         //console.log("current page number is: " + currentPageNumber)
         }, [data.currentDocID, shownPage, currentPageNumber]);
 
-    function fetchPageHighlight(subPageID) {
-        //LOGIC FOR TALKING TO SERVER HERE, GETTING HIGHLIGHT DATA, AND FORMATTING
-        //RETURN SO WE CAN SET WITH USESTATE
-
-        //return string of save data if availible
-
-        //return null if no entry
-        return null
-
-    }
 
     function chooseDocument(topLevelID, urls) {
         setData({currentDocID: topLevelID, pages: urls});
         setCurrentPageNumber(0)
+        setCurrentPageID(urls[currentPageNumber].id)
         setShowPage(urls[currentPageNumber].file)
-        let subPageID = urls[currentPageNumber].id
-        setPageHighlightData(fetchPageHighlight(subPageID))
+        setNeedHighlight(true)
     }
 
     function previousPage() {
@@ -53,7 +47,7 @@ export default function DocumentView() {
     }
 
     function nextPage() {
-        if(currentPageNumber != data.pages.length -1){
+        if(currentPageNumber !== data.pages.length -1){
             setCurrentPageNumber(currentPageNumber + 1)
         }
         else{
@@ -69,11 +63,11 @@ export default function DocumentView() {
 
         <header className="row2">
             <div className="documentList" >
-                <DocumentListLoader chooseDoc = {chooseDocument}/>
+                <DocumentListLoader chooseDoc = {chooseDocument} needHighlight = {needHighlight} setNeedHighlight={setNeedHighlight}/>
 
             </div>
             <div className="canvas">
-                <DocumentPage URL = {shownPage} highlighting = {pageHighlightData} />
+                <DocumentPage URL = {shownPage} highlighting = {pageHighlightData} currentPageID={currentPageID}/>
                 <div>
                     <Button onClick = { () => previousPage()}>Previous page</Button>
                     <Button onClick = { () => nextPage()}>Next page</Button>

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,8 @@
 
 const dev = false;
 const test = false;
-const prod = true;
-const testFrontProdBack = false;
+const prod = false;
+const testFrontProdBack = true;
 
 
 let api_url;


### PR DESCRIPTION
Frontend now pulls highlight from the server upon loading, document selection, and page selection. Old highlight is removed and the current highlight is loaded in.

To test:
1) log in with gram gram
2) try loading in the document titled "highlight test" in various orders - first document to load, click other document first then load it, etc
3) navigate through the pages of "highlight test document"
4) notice that highlight from the pages is always displayed on the correct page