### PR TITLE
added input validation to only accept certain filetypes

### DIFF
--- a/src/components/sidebars/DocumentList/PopUp.js
+++ b/src/components/sidebars/DocumentList/PopUp.js
@@ -88,7 +88,7 @@ function PopUp(){
                 <Form.Group className="mb-3" controlId="formFile" >
                     <Form.Label>File</Form.Label>
                     {/*<Form.Control type="file" placeholder="Browse computer" inputRef={(ref) => {this.file = ref}} required/>*/}
-                    <Form.Control type="file" placeholder="Browse computer" onChange={(e) => setFile(e.target.files[0])} required/>
+                    <Form.Control type="file" accept=".png, .pdf" placeholder="Browse computer" onChange={(e) => setFile(e.target.files[0])} required/>
                 </Form.Group>
 
                 {/*Mode Selection*/}

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,8 @@
 
 const dev = false;
 const test = false;
-const prod = true;
-const testFrontProdBack = false;
+const prod = false;
+const testFrontProdBack = true;
 
 
 let api_url;

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,8 @@
 
 const dev = false;
 const test = false;
-const prod = false;
-const testFrontProdBack = true;
+const prod = true;
+const testFrontProdBack = false;
 
 
 let api_url;


### PR DESCRIPTION
Test document upload - make sure you can upload a document/highlighted document which is formatted as a .pdf AND as a .png, but these file types only. Ensure that all other functionality works as intended. 